### PR TITLE
replace resource with GdImage

### DIFF
--- a/src/claviska/SimpleImage.php
+++ b/src/claviska/SimpleImage.php
@@ -17,6 +17,7 @@
 namespace claviska;
 
 use Exception;
+use GdImage;
 use League\ColorExtractor\Color;
 use League\ColorExtractor\ColorExtractor;
 use League\ColorExtractor\Palette;
@@ -64,7 +65,7 @@ class SimpleImage
 
     protected array $flags;
 
-    protected $image;
+    protected $image = null;
 
     protected string $mimeType;
 
@@ -115,10 +116,7 @@ class SimpleImage
      */
     public function __destruct()
     {
-        //Check for a valid GDimage instance
-        $type_check = (gettype($this->image) == 'object' && $this->image::class == 'GdImage');
-
-        if (is_resource($this->image) && $type_check) {
+        if ($this->image instanceof GdImage) {
             imagedestroy($this->image);
         }
     }
@@ -650,8 +648,8 @@ class SimpleImage
     /**
      * Same as PHP's imagecopymerge, but works with transparent images. Used internally for overlay.
      *
-     * @param  resource  $dstIm Destination image link resource.
-     * @param  resource  $srcIm Source image link resource.
+     * @param  GdImage  $dstIm Destination image.
+     * @param  GdImage  $srcIm Source image.
      * @param  int  $dstX x-coordinate of destination point.
      * @param  int  $dstY y-coordinate of destination point.
      * @param  int  $srcX x-coordinate of source point.
@@ -660,7 +658,7 @@ class SimpleImage
      * @param  int  $srcH Source height.
      * @return bool true if success.
      */
-    protected static function imageCopyMergeAlpha($dstIm, $srcIm, int $dstX, int $dstY, int $srcX, int $srcY, int $srcW, int $srcH, int $pct): bool
+    protected static function imageCopyMergeAlpha(GdImage $dstIm, GdImage $srcIm, int $dstX, int $dstY, int $srcX, int $srcY, int $srcW, int $srcH, int $pct): bool
     {
         // Are we merging with transparency?
         if ($pct < 100) {


### PR DESCRIPTION
fixes #325

changes:
1. import use of GdImage
2. initialize `$image` to null
3. changes to `__destruct`
4. edited docblock of `imageCopyMergeAlpha` to use `GdImage` instead of `resource`
5. typecheck `imageCopyMergeAlpha` parameters